### PR TITLE
[FIX] Add missing extension key for TYPO3 12 composer installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
             "role": "Developer"
         }
    ],
-  "type": "typo3-cms-extension"
+  "type": "typo3-cms-extension",
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "ai_translate"
+    }
+  }
 }


### PR DESCRIPTION
Fixes: #5